### PR TITLE
Changed KMeans OnlineParams fields to public

### DIFF
--- a/cluster/kmeans.go
+++ b/cluster/kmeans.go
@@ -146,8 +146,8 @@ type KMeans struct {
 // model if you want to learn using the
 // online version of the model
 type OnlineParams struct {
-	alpha    float64
-	features int
+	Alpha    float64
+	Features int
 }
 
 // NewKMeans returns a pointer to the k-means
@@ -163,14 +163,14 @@ type OnlineParams struct {
 func NewKMeans(k, maxIterations int, trainingSet [][]float64, params ...OnlineParams) *KMeans {
 	var features int
 	if len(params) != 0 {
-		features = params[0].features
+		features = params[0].Features
 	} else if len(trainingSet) != 0 {
 		features = len(trainingSet[0])
 	}
 
 	alpha := 0.5
 	if len(params) != 0 {
-		alpha = params[0].alpha
+		alpha = params[0].Alpha
 	}
 
 	// start all guesses with the zero vector.

--- a/cluster/kmeans_test.go
+++ b/cluster/kmeans_test.go
@@ -273,8 +273,8 @@ func TestOnlineKMeansShouldPass1(t *testing.T) {
 	errors := make(chan error, 20)
 
 	model := NewKMeans(4, 0, nil, OnlineParams{
-		alpha:    0.5,
-		features: 4,
+		Alpha:    0.5,
+		Features: 4,
 	})
 
 	go model.OnlineLearn(errors, stream, func(theta [][]float64) {})


### PR DESCRIPTION
The fields of the struct `OnlineParams` (KMeans package) were set in lowercase, so I changed them to upper to make them public and accessible from external packages.