### PR TITLE
add concurrency-friendly map access to fix #8

### DIFF
--- a/text/bayes.go
+++ b/text/bayes.go
@@ -83,7 +83,7 @@ import (
 
 	"golang.org/x/text/transform"
 
-	"github.com/piazzamp/goml/base"
+	"github.com/cdipaolo/goml/base"
 )
 
 /*

--- a/text/tfidf.go
+++ b/text/tfidf.go
@@ -173,5 +173,6 @@ func TermFrequencies(document []string) Frequencies {
 // Look at the TFIDF docs to see more about how
 // this is calculated
 func (t *TFIDF) InverseDocumentFrequency(word string) float64 {
-	return math.Log(float64(t.DocumentCount)) - math.Log(float64(t.Words[word].DocsSeen)+1)
+	w, _ := t.Words.Get(word)
+	return math.Log(float64(t.DocumentCount)) - math.Log(float64(w.DocsSeen)+1)
 }


### PR DESCRIPTION
Created a new type `histogram` that couples a `sync.RWMutex` and the existing map. The type itself isn't exported (no one should be instantiating these, right?), but its `Get` and `Set` methods are. This is a significant change for consumers that create their own `NaiveBayes` struct without calling `NewNaiveBayes`.