### PR TITLE
Add support for specifying a custom tokenizer on the NaiveBayes model

### DIFF
--- a/text/tfidf.go
+++ b/text/tfidf.go
@@ -3,7 +3,6 @@ package text
 import (
 	"math"
 	"sort"
-	"strings"
 
 	"golang.org/x/text/transform"
 )
@@ -81,7 +80,7 @@ func (f Frequencies) Swap(i, j int) {
 // this is calculated
 func (t *TFIDF) TFIDF(word string, sentence string) float64 {
 	sentence, _, _ = transform.String(t.sanitize, sentence)
-	document := strings.Split(strings.ToLower(sentence), " ")
+	document := t.tokenize(sentence)
 
 	return t.TermFrequency(word, document) * t.InverseDocumentFrequency(word)
 }
@@ -96,7 +95,7 @@ func (t *TFIDF) TFIDF(word string, sentence string) float64 {
 // by importance
 func (t *TFIDF) MostImportantWords(sentence string, n int) Frequencies {
 	sentence, _, _ = transform.String(t.sanitize, sentence)
-	document := strings.Split(strings.ToLower(sentence), " ")
+	document := t.tokenize(sentence)
 
 	freq := TermFrequencies(document)
 	for i := range freq {


### PR DESCRIPTION
In some cases, it may be useful to allow people to specify their own tokenizer in the same way as the sanitizer. The tokenizer can not be added to the "constructor" function since that would break API compatibility, so add a public setter instead.

The primary use case for this is to allow people to pre-process the tokens, for example, by running the tokens through a stemmer. Without support for a custom tokenizer, the only way to accomplish this is to split, stem and re-join the sentence only to be split again which is suboptimal. 